### PR TITLE
Set user agent string

### DIFF
--- a/src/BrazeClient.php
+++ b/src/BrazeClient.php
@@ -121,6 +121,7 @@ class BrazeClient
         $headers = [
             'Accept' => 'application/json',
             'Content-Type' => 'application/json',
+            'User-Agent' => 'braze-client php',
         ];
 
         if (!empty($this->apiKey)) {


### PR DESCRIPTION
I'm an engineer at Braze and we're trying to gather some usage data on the various community supported client libraries that exist. It would help us out to include this user agent string to identify the PHP client.

Thanks so much for building and maintaining this project! Let me know if you have any questions.